### PR TITLE
Fix license in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
         "flarum", "private", "login", "signup", "page"
     ],
     "type": "flarum-extension",
-    "license": "mit",
+    "license": "MIT",
     "require": {
         "flarum/core": "^1.2.0"
     },


### PR DESCRIPTION
It fixes license detection in some services, for example ![](https://img.shields.io/packagist/l/sycho/flarum-private-facade) vs ![](https://img.shields.io/packagist/l/sycho/flarum-move-posts)